### PR TITLE
Magento 2.3.5 compatibility

### DIFF
--- a/Model/Entity/Attribute/Backend/Image.php
+++ b/Model/Entity/Attribute/Backend/Image.php
@@ -44,9 +44,10 @@ class Image extends \Magento\Catalog\Model\Category\Attribute\Backend\Image
         \Psr\Log\LoggerInterface $logger,
         \Magento\Framework\Filesystem $filesystem,
         \Magento\MediaStorage\Model\File\UploaderFactory $fileUploaderFactory,
+        \Magento\Store\Model\StoreManagerInterface $storeManager = null,
         \Magento\Catalog\Model\ImageUploader $imageUploader = null
     ) {
-        parent::__construct($logger, $filesystem, $fileUploaderFactory);
+        parent::__construct($logger, $filesystem, $fileUploaderFactory, $storeManager, $imageUploader);
         $this->imageUploader = $imageUploader;
     }
 


### PR DESCRIPTION
Fix "Missing required argument $baseTmpPath of Magento\Catalog\Model\ImageUploader"