### PR TITLE
fix: patch php 8.1 compatibility

### DIFF
--- a/Controller/Adminhtml/Set/Save.php
+++ b/Controller/Adminhtml/Set/Save.php
@@ -78,11 +78,11 @@ class Save extends \Smile\ScopedEav\Controller\Adminhtml\AbstractSet
         $attributeSet = $this->getAttributeSet();
 
         try {
-            $attributeSet->setAttributeSetName($this->filterManager->stripTags($this->getRequest()->getParam('attribute_set_name')));
+            $attributeSet->setAttributeSetName($this->filterManager->stripTags((string) $this->getRequest()->getParam('attribute_set_name')));
 
             if ($isNewSet === false) {
                 $data = $this->jsonHelper->jsonDecode($this->getRequest()->getPost('data'));
-                $data['attribute_set_name'] = $this->filterManager->stripTags($data['attribute_set_name']);
+                $data['attribute_set_name'] = $this->filterManager->stripTags((string) $data['attribute_set_name']);
                 $attributeSet->organizeData($data);
             }
 

--- a/Ui/DataProvider/Entity/Form/EavValidationRules.php
+++ b/Ui/DataProvider/Entity/Form/EavValidationRules.php
@@ -40,7 +40,7 @@ class EavValidationRules
             $rules['required-entry'] = true;
         }
 
-        $validationClasses = explode(' ', $attribute->getFrontendClass());
+        $validationClasses = explode(' ', (string) $attribute->getFrontendClass());
 
         foreach ($validationClasses as $class) {
             if (preg_match('/^maximum-length-(\d+)$/', $class, $matches)) {


### PR DESCRIPTION
Good afternoon,

Changes to correct issues with migration to PHP 8.1 - fix "Deprecated Passing null to parameter error".

Ilan Parmentier