### PR TITLE
fix: resolve texteditor and pagebuilder ui form input fields

### DIFF
--- a/Ui/DataProvider/Entity/Form/Modifier/Eav.php
+++ b/Ui/DataProvider/Entity/Form/Modifier/Eav.php
@@ -178,7 +178,10 @@ class Eav extends AbstractModifier
         );
 
         /** @var EavAttribute $attribute */
-        if ($attribute->getIsWysiwygEnabled()) {
+        if (
+            $attribute->getFrontendInput() == 'texteditor' ||
+            $attribute->getIsWysiwygEnabled()
+        ) {
             $containerMeta = $this->arrayManager->merge(
                 self::META_CONFIG_PATH,
                 $containerMeta,
@@ -303,6 +306,8 @@ class Eav extends AbstractModifier
                 $meta = $this->customizeCheckbox($attribute, $meta);
                 break;
             case 'textarea':
+            case 'texteditor':
+            case 'pagebuilder':
                 $meta = $this->customizeWysiwyg($attribute, $meta);
                 break;
             case 'image':
@@ -517,7 +522,10 @@ class Eav extends AbstractModifier
     private function customizeWysiwyg(AttributeInterface $attribute, array $meta): array
     {
         /** @var EavAttribute $attribute */
-        if (!$attribute->getIsWysiwygEnabled()) {
+        if (
+            !in_array($attribute->getFrontendInput(), ['texteditor', 'pagebuilder']) ||
+            $attribute->getFrontendInput() == 'textarea' && !$attribute->getIsWysiwygEnabled()
+        ) {
             return $meta;
         }
 
@@ -530,6 +538,11 @@ class Eav extends AbstractModifier
             'use_container' => true,
             'container_class' => 'hor-scroll',
         ];
+
+        if (in_array($attribute->getFrontendInput(), ['texteditor', 'pagebuilder'])) {
+            $meta['arguments']['data']['config']['wysiwygConfigData']['is_pagebuilder_enabled'] =
+                ($attribute->getFrontendInput() == 'pagebuilder' ? true : false);
+        }
 
         return $meta;
     }


### PR DESCRIPTION
**Environment** : Magento : 2.4.6-p4 & last versions of Smile_CustomEntity, Smile_CustomEntityProductLink, Smile_ScopedEav

**Reference issue** : 
#29 

Please note after this PR is merged on installation, it will resolve issue #29 

Screenshots : 

Pagebuilder field :
<img width="1352" alt="Capture d’écran 2024-03-18 à 20 36 25" src="https://github.com/Smile-SA/magento2-module-scoped-eav/assets/2975845/e6fac171-fe8d-4904-830a-ae166d129fbe">

Texteditor field : 
<img width="1346" alt="Capture d’écran 2024-03-18 à 20 36 54" src="https://github.com/Smile-SA/magento2-module-scoped-eav/assets/2975845/e83598f8-3cf2-4dc5-8740-ba7f4b0942f8">

If you have a more elegant way to solve the issue, please comments.